### PR TITLE
Add SetsRequiredMembersAttribute class

### DIFF
--- a/MissingAttributes/MissingAttributes.csproj
+++ b/MissingAttributes/MissingAttributes.csproj
@@ -21,6 +21,7 @@
 		<None Include="CompilerFeatureRequiredAttribute.cs" />
 		<None Include="IsExternalInit.cs" />
 		<None Include="RequiredMemberAttribute.cs" />
+		<None Include="SetsRequiredMembersAttribute.cs" />
 	</ItemGroup>
 
 </Project>

--- a/MissingAttributes/SetsRequiredMembersAttribute.cs
+++ b/MissingAttributes/SetsRequiredMembersAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace System.Diagnostics.CodeAnalysis;
+
+[System.AttributeUsage(System.AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+public sealed class SetsRequiredMembersAttribute : Attribute
+{
+}


### PR DESCRIPTION
- Added `SetsRequiredMembersAttribute.cs` defining a new attribute class `SetsRequiredMembersAttribute` in the `System.Diagnostics.CodeAnalysis` namespace.
- Updated `MissingAttributes.csproj` to include the new file for the `net6.0` target framework.
- The attribute is designed for constructors, marked as `sealed`, and cannot be used multiple times on the same constructor or inherited by derived classes.